### PR TITLE
Wrong behaviour without external probe

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -344,7 +344,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
 #ifdef EXTERNAL_ENDSTOP_Z_PROBING
  #define EXTERNAL_ENDSTOP_Z_PROBING_PIN 71
- //#define EXTERNAL_Z_ENDSTOP_INVERTING false
+ #define EXTERNAL_Z_ENDSTOP_INVERTING true
 #endif
 //============================= Bed Auto Leveling ===========================
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -341,6 +341,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 //= Z PROBING via endstop (e.g. electrical continuity between mill and PCB)==
 
 #define EXTERNAL_ENDSTOP_Z_PROBING
+//#undef EXTERNAL_ENDSTOP_Z_PROBING
 
 #ifdef EXTERNAL_ENDSTOP_Z_PROBING
  #define EXTERNAL_ENDSTOP_Z_PROBING_PIN 71

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -391,9 +391,6 @@ extern unsigned int general_assembly_version;
 #define SERIAL_N_5             6
 #define SERIAL_N_CRC           7
 
-//external endstop probing
-extern bool external_z_endstop_inverting;
-
 #define I2C_MAX_TIMEOUT 1000
 
 #define AVG_MEASURED_Z_MAX     1

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -265,6 +265,10 @@ extern unsigned int ERROR_CODE;
 
 extern bool head_placed;
 
+#ifdef EXTERNAL_ENDSTOP_Z_PROBING
+extern bool enable_secure_switch_zprobe;
+#endif
+
 // Handling multiple extruders pins
 extern uint8_t active_extruder;
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -436,8 +436,6 @@ bool rpi_recovery_flag=false;
 
 #ifdef EXTERNAL_ENDSTOP_Z_PROBING
 bool enable_secure_switch_zprobe=false;
-bool external_z_endstop_inverting=false;
-
 #endif
 
 float rpm = 0;
@@ -693,7 +691,7 @@ blue_fading=false;
 slope=true;*/
 
 set_amb_color(0,0,0);
-set_amb_color_fading(true,true,false,fading_speed);
+set_amb_color_fading(true,true,false,200);
 
 
 Read_Head_Info();
@@ -1416,7 +1414,7 @@ static void homeaxis(int axis) {
     
     plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feedrate/60, active_extruder);
     st_synchronize();
-    if (!home_Z_reverse && axis==Z_AXIS) set_amb_color_fading(false,true,false,fading_speed);
+    if (!home_Z_reverse && axis==Z_AXIS) set_amb_color_fading(false,true,false,100);
 
     current_position[axis] = 0;
     plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
@@ -1424,7 +1422,7 @@ static void homeaxis(int axis) {
     plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feedrate/60, active_extruder);
     st_synchronize();
     if (!home_Z_reverse && axis==Z_AXIS) {
-      set_amb_color_fading(false,true,false,fading_speed);
+      set_amb_color_fading(false,true,false,100);
       retract_z_probe();
       engage_z_probe();
     }
@@ -1605,7 +1603,7 @@ void process_commands()
   #endif //ENABLE_AUTO_BED_LEVELING
   
         store_last_amb_color();
-        set_amb_color_fading(false,true,false,fading_speed);
+        set_amb_color_fading(false,true,false,100);
         
         
         saved_feedrate = feedrate;
@@ -1847,7 +1845,7 @@ void process_commands()
             #endif
 
             store_last_amb_color();
-            set_amb_color_fading(false,true,false,fading_speed);
+            set_amb_color_fading(false,true,false,100);
             
         
             // Prevent user from running a G29 without first homing in X and Y
@@ -2076,7 +2074,6 @@ void process_commands()
 	     // Same behaviour as G30 but with an endstop external z probe connected as described in M746
 	     // It does nothing unless the probe is enabled first with M746 S1
         {
-          
           if(!Stopped && enable_secure_switch_zprobe){
             
             st_synchronize();
@@ -3779,9 +3776,9 @@ void process_commands()
       
       set_amb_color(0,0,0);
       store_last_amb_color();
-      set_amb_color_fading(true,true,true,fading_speed);
-      //_delay_ms(45000);
-      //restore_last_amb_color();
+      set_amb_color_fading(true,true,false,200);
+      _delay_ms(45000);
+      restore_last_amb_color();
        //while(1){}
       
     }
@@ -4045,12 +4042,10 @@ void process_commands()
         value = code_value();
         if(value>=1)
         {
-          external_z_endstop_inverting = true;
           enable_secure_switch_zprobe=true;
         }
         else
         {
-          external_z_endstop_inverting = false;
           enable_secure_switch_zprobe=false;
         }
       }
@@ -4767,14 +4762,13 @@ void manage_inactivity()
      kill_by_door();                    // if the FABtotum is working and the user opens the front door the FABtotum will be disabled
     }
 
- //if ((READ(Z_MAX_PIN)^Z_MAX_ENDSTOP_INVERTING) && (READ(Z_MIN_PIN)^Z_MIN_ENDSTOP_INVERTING))
-    //{
-    //rpi_recovery_flag=true;
-    //RPI_RECOVERY_ON();          //check if user is going to recover Raspberry OS
-    //stop_fading();
-    //set_amb_color(0,0,255);
-    //}
-    
+ if ((READ(X_MAX_PIN)^X_MAX_ENDSTOP_INVERTING) && (READ(X_MIN_PIN)^X_MIN_ENDSTOP_INVERTING))
+    {
+    rpi_recovery_flag=true;
+    RPI_RECOVERY_ON();          //check if user is going to recover Raspberry OS
+    stop_fading();
+    set_amb_color(0,0,255);
+     }
  else
      {
        if(rpi_recovery_flag)

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -100,7 +100,7 @@ volatile signed char count_direction[NUM_AXIS] = { 1, 1, 1, 1};
 #define CHECK_ENDSTOPS  if(check_endstops)
 
 #ifdef EXTERNAL_ENDSTOP_Z_PROBING
-#define CHECK_EXTERNAL_Z_ENDSTOPS  if(check_external_z_endstops)
+#define CHECK_EXTERNAL_Z_ENDSTOPS  if(check_external_z_endstops && enable_secure_switch_zprobe)
 #endif
 
 // intRes = intIn1 * intIn2 >> 16
@@ -522,18 +522,18 @@ ISR(TIMER1_COMPA_vect)
         #endif
       }
 
-       #if defined(EXTERNAL_ENDSTOP_Z_PROBING)
+      #if defined(EXTERNAL_ENDSTOP_Z_PROBING)
       CHECK_EXTERNAL_Z_ENDSTOPS
       {
-         bool external_endstop=(READ(EXTERNAL_ENDSTOP_Z_PROBING_PIN) != EXTERNAL_Z_ENDSTOP_INVERTING);
+          bool external_endstop=(READ(EXTERNAL_ENDSTOP_Z_PROBING_PIN) != EXTERNAL_Z_ENDSTOP_INVERTING);
           if(external_endstop && old_external_z_endstop && (current_block->steps_z > 0)) {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
             endstop_z_hit=true;
             step_events_completed = current_block->step_event_count;
           }
           old_external_z_endstop = external_endstop;
-      #endif
      }
+     #endif
     }
     else { // +direction
       WRITE(Z_DIR_PIN,!INVERT_Z_DIR);

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -522,18 +522,18 @@ ISR(TIMER1_COMPA_vect)
         #endif
       }
 
-      #if defined(EXTERNAL_ENDSTOP_Z_PROBING)
+       #if defined(EXTERNAL_ENDSTOP_Z_PROBING)
       CHECK_EXTERNAL_Z_ENDSTOPS
       {
-         bool external_endstop=(READ(EXTERNAL_ENDSTOP_Z_PROBING_PIN) != external_z_endstop_inverting );
+         bool external_endstop=(READ(EXTERNAL_ENDSTOP_Z_PROBING_PIN) != EXTERNAL_Z_ENDSTOP_INVERTING);
           if(external_endstop && old_external_z_endstop && (current_block->steps_z > 0)) {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
             endstop_z_hit=true;
             step_events_completed = current_block->step_event_count;
           }
           old_external_z_endstop = external_endstop;
-      }
       #endif
+     }
     }
     else { // +direction
       WRITE(Z_DIR_PIN,!INVERT_Z_DIR);


### PR DESCRIPTION
This should have fixed it.

I have checked that G28 works in the right direction without probe connected (though now has an additional probe retraction/extension and a ultra slow second touch, I guess this is intended by your code). I have also checked that G38 works with the probe connected.

Double check it, because I hate Arduino IDE's behaviour where you can compile something that is not written to disk and would not be the first time I commit an incomplete commit...
